### PR TITLE
Remove unlinkability implication from issuance secrecy

### DIFF
--- a/draft-ietf-privacypass-architecture.md
+++ b/draft-ietf-privacypass-architecture.md
@@ -257,8 +257,7 @@ about the Client's private input, including the challenge and nonce, to the
 Attester or Issuer, regardless of the hardness assumptions of the underlying
 cryptographic protocol(s). The issuance protocol can reveal the Issuer public
 key for the purposes of determining which private key to use in producing the
-token. A result of this property is that the redemption flow is unlinkable
-from the issuance flow.
+token.
 1. One-more forgery security. The issuance protocol MUST NOT allow malicious
 Clients or Attesters (acting as Clients) to forge tokens offline or otherwise
 without interacting with the Issuer directly.


### PR DESCRIPTION
Closes #185.

cc @nikitaborisov