### PR TITLE
Make the media type registrations compact

### DIFF
--- a/draft-ietf-privacypass-protocol.md
+++ b/draft-ietf-privacypass-protocol.md
@@ -647,7 +647,7 @@ Fragment identifier considerations:
 
 Additional information:
 
-: <dl>
+: <dl spacing="compact">
   <dt>Magic number(s):</dt><dd>N/A</dd>
   <dt>Deprecated alias names for this type:</dt><dd>N/A</dd>
   <dt>File extension(s):</dt><dd>N/A</dd>
@@ -673,6 +673,7 @@ Author:
 Change controller:
 
 : IESG
+{: spacing="compact"}
 
 ### "application/private-token-response" media type
 
@@ -718,7 +719,7 @@ Fragment identifier considerations:
 
 Additional information:
 
-: <dl>
+: <dl spacing="compact">
   <dt>Magic number(s):</dt><dd>N/A</dd>
   <dt>Deprecated alias names for this type:</dt><dd>N/A</dd>
   <dt>File extension(s):</dt><dd>N/A</dd>
@@ -744,6 +745,7 @@ Author:
 Change controller:
 
 : IESG
+{: spacing="compact"}
 
 --- back
 


### PR DESCRIPTION
Once I worked out how to do this, I did this everywhere I could.  These templates are nuts.