### PR TITLE
Redemption context unlinkability

### DIFF
--- a/draft-ietf-privacypass-architecture.md
+++ b/draft-ietf-privacypass-architecture.md
@@ -283,8 +283,14 @@ the same issuance context is referred to as an issuance anonymity set.
 3. Attester-Origin unlinkability. This is similar to Origin-Client and
 Issuer-Client unlinkability. It means that given two attestation contexts,
 the Attester cannot determine if both contexts correspond to the same Origin
-or two different Origins. The set of Clients that share the same attestation
+or two different Origins. The set of Origins that share the same attestation
 context is referred to as an attestation anonymity set.
+4. Redemption context unlinkability. Given two redemption contexts, the Origin
+cannot determine which issuance and attestation contexts each redemption
+corresponds to, even with the collaboration of the Issuer and Attester (should
+these be different parties). This means that any information that may be learned
+about the Client during the issuance and attestation flows cannot be used by the
+Origin to compromise Client privacy.
 
 By ensuring that different contexts cannot be linked in this way, only the
 Client is able to correlate information that might be used to identify them with


### PR DESCRIPTION
The unlinkability properties in the architecture document discuss the unlinkability of clients/origins in each individual context (attestation, issuance, redemption). An important property of privacy pass, as I understand it, is the unlinkability of the contexts themselves. So I added another property, calling it "Redemption context unlinkability" that adds this as a specific goal. (There may be a more descriptive name?)

I also took the liberty of editing the Attestation-Origin anonymity paragraph; I'm pretty sure the relevant anonymity  set here is a set of Origins, not a set of Clients. 