### PR TITLE
Fix formatting for HTTP examples.

### DIFF
--- a/.lint.py
+++ b/.lint.py
@@ -7,7 +7,7 @@ import re
 parser = argparse.ArgumentParser(description="Lint markdown drafts.")
 parser.add_argument("files", metavar="file", nargs="+", help="Files to lint")
 parser.add_argument("-l", dest="maxLineLength", default=80)
-parser.add_argument("-f", dest="maxFigureLineLength", default=65)
+parser.add_argument("-f", dest="maxFigureLineLength", default=69)
 
 args = parser.parse_args()
 

--- a/draft-ietf-privacypass-auth-scheme.md
+++ b/draft-ietf-privacypass-auth-scheme.md
@@ -922,7 +922,9 @@ the token-key parameter for the first challenge in the list, whereas
 token-key-1 denotes the token-key for the second challenge in the list.
 
 The resulting wire-encoded WWW-Authentication header based on this
-list of challenges is then listed at the end.
+list of challenges is then listed at the end. Line folding is only
+used to fit the document formatting constraints and not unsupported
+in actual requests.
 
 ~~~
 token-type-0: 0x0002


### PR DESCRIPTION
- Fix figure line length (set to 69 to match output limits).
- Note use of obs-fold is just for presentation.

Fixes #436 and #436.