### PR TITLE
Make reference to the PrivateToken object

### DIFF
--- a/draft-ietf-privacypass-auth-scheme.md
+++ b/draft-ietf-privacypass-auth-scheme.md
@@ -78,7 +78,7 @@ interaction between client and origin is shown below.
 | Origin |                              | Client |
 +---+----+                              +---+----+
     |                                       |
-    +-- WWW-Authenticate: TokenChallenge -->|
+    +-- WWW-Authenticate: PrivateToken ---->|
     |                                       |
     |                            (Run issuance protocol)
     |                                       |


### PR DESCRIPTION
The `Authorization:` header contains a `Token` object, as well as the `WWW-Authenticate:` header contains a `PrivateToken` object.
